### PR TITLE
align examples with previous page

### DIFF
--- a/docs/intro_to_graphs.rst
+++ b/docs/intro_to_graphs.rst
@@ -13,8 +13,8 @@ RDFLib graphs override :meth:`~rdflib.graph.Graph.__iter__` in order to support 
 
 .. code-block:: python
 
-    for subject,predicate,obj in someGraph:
-       if not (subject,predicate,obj) in someGraph: 
+    for subject,predicate,obj in g:
+       if not (subject,predicate,obj) in g: 
           raise Exception("Iterator / Container Protocols are Broken!!")
 
 Contains check
@@ -22,10 +22,7 @@ Contains check
 
 Graphs implement :meth:`~rdflib.graph.Graph.__contains__`, so you can check if a triple is in a graph with ``triple in graph`` syntax::
 
-  from rdflib import URIRef
-  from rdflib.namespace import RDF 
-  bob = URIRef("http://example.org/people/bob")
-  if ( bob, RDF.type, FOAF.Person ) in graph: 
+  if ( bob, RDF.type, FOAF.Person ) in g: 
      print "This graph knows that Bob is a person!"
 	 
 Note that this triple does not have to be completely bound::


### PR DESCRIPTION
This example uses data introduced in the previous page
Change the variable name from graph to g 
the example now continues from the previous page and so does not need to import or to recreate bob
